### PR TITLE
Test

### DIFF
--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -44,7 +44,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
 
                 // Assert
                 var actualMessage = await db.FindAsync<Message>(recId);
-                Assert.Equal("Test Data", actualMessage);
+                Assert.Equal(new Message() { Id = recId, Text = "Test" }, actualMessage);
             }
         }
 


### PR DESCRIPTION
This pull request includes a small change to the `AddMessageAsync_MessageIsAdded` test method in the `DataAccessLayerTest` class. The change updates the assertion to compare the entire `Message` object instead of just the `Text` property.

* [`src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs`](diffhunk://#diff-759cd6dbf2cedcb026f64771a32e9837bd979c7b48a52cae4dbd208ece5a69b4L47-R47): Updated the assertion in `AddMessageAsync_MessageIsAdded` to compare the entire `Message` object.