### PR TITLE
Fix test

### DIFF
--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -44,7 +44,7 @@ namespace RazorPagesTestSample.Tests.UnitTests
 
                 // Assert
                 var actualMessage = await db.FindAsync<Message>(recId);
-                Assert.Equal(new Message() { Id = recId, Text = "Test" }, actualMessage);
+                Assert.Equal(expectedMessage, actualMessage);
             }
         }
 


### PR DESCRIPTION
This pull request includes a small but important change to the unit test `AddMessageAsync_MessageIsAdded` in the `DataAccessLayerTest` class. The change simplifies the assertion by using an existing variable for comparison instead of creating a new `Message` object.

* [`src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs`](diffhunk://#diff-759cd6dbf2cedcb026f64771a32e9837bd979c7b48a52cae4dbd208ece5a69b4L47-R47): Modified the assertion in the `AddMessageAsync_MessageIsAdded` test to compare `actualMessage` with `expectedMessage` instead of a new `Message` object.
Resolves #20 